### PR TITLE
remove method on IntIntMultiMap fixed

### DIFF
--- a/collections/src/main/java/net/openhft/collections/IntIntMultiMap.java
+++ b/collections/src/main/java/net/openhft/collections/IntIntMultiMap.java
@@ -106,7 +106,8 @@ public class IntIntMultiMap {
         size--;
         int pos2 = pos;
         // now work back up the chain from pos to pos0;
-        while (pos >= pos0) {
+        // Note: because of the mask, the pos can be actually less than pos0, thus using != operator instead of >=
+        while (pos != pos0) {
             pos = (pos - ENTRY_SIZE) & capacityMask2;
             int key2 = bytes.readInt(pos + KEY);
             if (key2 == key) {

--- a/collections/src/test/java/net/openhft/collections/IntIntMultiMapTest.java
+++ b/collections/src/test/java/net/openhft/collections/IntIntMultiMapTest.java
@@ -78,4 +78,16 @@ public class IntIntMultiMapTest {
         assertEquals(2, map.size());
         assertEquals("{ 3=33, 3=32 }", map.toString());
     }
+    
+    @Test
+    public void testPutRemoveLoop() {
+    	// Testing a specific case when the remove method on the map does (did) not work as expected. The size goes correctly to
+    	// 0 but the value is still present in the map.
+    	IntIntMultiMap map = new IntIntMultiMap(10);
+    	
+    	map.put(15, 1);
+		map.remove(15, 1);
+		map.startSearch(15);    		
+		assertEquals(IntIntMultiMap.UNSET, map.nextInt());
+    }
 }

--- a/collections/src/test/java/net/openhft/collections/IntIntMultiMapTest.java
+++ b/collections/src/test/java/net/openhft/collections/IntIntMultiMapTest.java
@@ -80,7 +80,7 @@ public class IntIntMultiMapTest {
     }
     
     @Test
-    public void testPutRemoveLoop() {
+    public void testRemoveSpecific() {
     	// Testing a specific case when the remove method on the map does (did) not work as expected. The size goes correctly to
     	// 0 but the value is still present in the map.
     	IntIntMultiMap map = new IntIntMultiMap(10);


### PR DESCRIPTION
While I was testing HugeHashMap, I noticed that the remove method on the HugeHashMap does not work in some specific cases. After some investigation I found an issue in IntIntMultiMap causing the issue in HugeHashMap. This pull request provides a possible fix for this issue. Please review the fix or provide an alternative.

I'd like to make more changes to HugeHashMap - I'll issue another pull request once it is decided about this request.

Regards,
Jaromir
