### PR TITLE
HugeHashMap: recyclable vs immutable key

### DIFF
--- a/collections/src/main/java/net/openhft/collections/HugeHashMap.java
+++ b/collections/src/main/java/net/openhft/collections/HugeHashMap.java
@@ -243,8 +243,7 @@ public class HugeHashMap<K extends HugeMapKey<K>, V> extends AbstractMap<K, V> i
             while (true) {
                 int pos = smallMap.nextInt();
                 if (pos == IntIntMultiMap.UNSET) {
-                    Object key2 = key instanceof CharSequence ? key.toString() : key;
-                    final DirectStore store = map.get(key2);
+                    final DirectStore store = map.get(key);
                     if (store == null) {
                         if (ifPresent && !ifAbsent)
                             return;
@@ -329,9 +328,8 @@ public class HugeHashMap<K extends HugeMapKey<K>, V> extends AbstractMap<K, V> i
             smallMap.startSearch(hash);
             while (true) {
                 int pos = smallMap.nextInt();
-                if (pos == IntIntMultiMap.UNSET) {
-                    Object key2 = key instanceof CharSequence ? key.toString() : key;
-                    final DirectStore store = map.get(key2);
+                if (pos == IntIntMultiMap.UNSET) {                    
+                    final DirectStore store = map.get(key);
                     if (store == null)
                         return null;
                     bytes.storePositionAndSize(store, 0, store.size());
@@ -355,15 +353,6 @@ public class HugeHashMap<K extends HugeMapKey<K>, V> extends AbstractMap<K, V> i
             return (V) bytes.readObject();
         }
 
-        private static boolean equalsCS(CharSequence key, CharSequence key2) {
-            if (key.length() != key2.length())
-                return false;
-            for (int i = 0; i < key.length(); i++)
-                if (key.charAt(i) != key2.charAt(i))
-                    return false;
-            return true;
-        }
-
         private K getKey() {
             keyFlyweigh.readMarshallable(bytes);
             return keyFlyweigh;
@@ -376,8 +365,7 @@ public class HugeHashMap<K extends HugeMapKey<K>, V> extends AbstractMap<K, V> i
             while (true) {
                 int pos = smallMap.nextInt();
                 if (pos == IntIntMultiMap.UNSET) {
-                    Object key2 = key instanceof CharSequence ? key.toString() : key;
-                    return map.containsKey(key2);
+                    return map.containsKey(key);
                 }
                 bytes.storePositionAndSize(store, pos * smallEntrySize, smallEntrySize);
                 K key2 = getKey();
@@ -406,8 +394,7 @@ public class HugeHashMap<K extends HugeMapKey<K>, V> extends AbstractMap<K, V> i
                     break;
                 }
             }
-            Object key2 = key instanceof CharSequence ? key.toString() : key;
-            DirectStore remove = map.remove(key2);
+            DirectStore remove = map.remove(key);
             if (remove == null)
                 return found;
             offHeapUsed -= remove.size();

--- a/collections/src/main/java/net/openhft/collections/HugeMapKey.java
+++ b/collections/src/main/java/net/openhft/collections/HugeMapKey.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2014 Peter Lawrey
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.openhft.collections;
+
+import net.openhft.lang.io.serialization.BytesMarshallable;
+
+public interface HugeMapKey<K extends HugeMapKey<K>> extends BytesMarshallable {
+	K createKeyForPut();
+}

--- a/collections/src/main/java/net/openhft/collections/IntIntMultiMap.java
+++ b/collections/src/main/java/net/openhft/collections/IntIntMultiMap.java
@@ -122,7 +122,7 @@ public class IntIntMultiMap {
         }
         pos = (pos + ENTRY_SIZE) & capacityMask2;
         // re-inset any values in between pos and pos2.
-        while (pos < pos2) {
+        while (pos != pos2) {
             int key2 = bytes.readInt(pos + KEY);
             int value2 = bytes.readInt(pos + VALUE);
             // clear the entry

--- a/collections/src/test/java/net/openhft/collections/CharSequenceKey.java
+++ b/collections/src/test/java/net/openhft/collections/CharSequenceKey.java
@@ -1,0 +1,100 @@
+package net.openhft.collections;
+
+import net.openhft.lang.LongHashable;
+import net.openhft.lang.Maths;
+import net.openhft.lang.io.Bytes;
+
+public abstract class CharSequenceKey implements HugeMapKey<CharSequenceKey>, LongHashable {
+	private static class ImmutableKey extends CharSequenceKey {
+		private final String value;
+		
+		public ImmutableKey(String value) {
+			this.value = value;
+		}
+		
+		public String getValue() { return value; }
+		
+		@Override
+		public CharSequenceKey createKeyForPut() {
+			// Method not used on immutable key.
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public void set(CharSequence prefix, int key) {
+			// Method not used on immutable key.
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public void readMarshallable(Bytes in) throws IllegalStateException {
+			// Method not used on immutable key.
+			throw new UnsupportedOperationException();
+		}
+	}
+	
+	private static class RecyclableKey extends CharSequenceKey {
+		private final StringBuilder builder = new StringBuilder();
+		
+		@Override
+		public CharSequenceKey createKeyForPut() {
+			return new ImmutableKey(builder.toString());
+		}
+
+		@Override
+		protected CharSequence getValue() {
+			return builder;
+		}
+		
+		@Override
+		public void set(CharSequence prefix, int key) {
+			builder.setLength(0);
+			builder.append(prefix);
+			builder.append(key);
+		}
+		
+		@Override
+		public void readMarshallable(Bytes in) throws IllegalStateException {
+			builder.setLength(0);
+			in.readUTFΔ(builder);
+		}		
+	}
+	
+	public static  CharSequenceKey createRecyclableKey() {
+		return new RecyclableKey();
+	}
+
+	@Override
+	public abstract void readMarshallable(Bytes in) throws IllegalStateException;
+
+	@Override
+	public void writeMarshallable(Bytes out) {
+		out.writeUTFΔ(getValue());
+	}
+	
+	public abstract void set(CharSequence prefix, int key);
+	
+	protected abstract CharSequence getValue();
+	
+	@Override
+	public long longHashCode() {
+		return Maths.hash(getValue());
+	}
+	
+	@Override
+	public int hashCode() {
+		return (int)longHashCode();
+	}
+	
+	@Override
+	public boolean equals(Object obj) {
+		if (obj == null || !(obj instanceof CharSequenceKey)) return false;
+		CharSequenceKey key2 = (CharSequenceKey)obj;
+		if (getValue().length() != key2.getValue().length())
+             return false;
+        for (int i = 0; i < getValue().length(); i++)
+             if (getValue().charAt(i) != key2.getValue().charAt(i))
+                 return false;
+        return true;
+	}
+}

--- a/collections/src/test/java/net/openhft/collections/HugeHashMapTest.java
+++ b/collections/src/test/java/net/openhft/collections/HugeHashMapTest.java
@@ -178,12 +178,12 @@ public class HugeHashMapTest {
         HugeHashMap<IntKey, Long> map1 =
                 new HugeHashMap<IntKey, Long>(config, factory, IntKey.class, Long.class);
 
-        IntKey key = new IntKey();
+        IntKey key = new IntKey().set(55);
 
-        map1.put(key.set(11), 10L);
-        assertEquals(10L, map1.get(key.set(11)));
-        map1.put(key.set(11), 20L);
-        assertEquals(20L, map1.get(key.set(11)));
+        map1.put(key, 10L);
+        assertEquals(10L, map1.get(key));
+        map1.put(key, 20L);
+        assertEquals(20L, map1.get(key));
         map1.clear();
     }
 }

--- a/collections/src/test/java/net/openhft/collections/HugeHashMapTest.java
+++ b/collections/src/test/java/net/openhft/collections/HugeHashMapTest.java
@@ -16,6 +16,8 @@
 
 package net.openhft.collections;
 
+import net.openhft.collections.HugeHashMap.KeyFlyweighFactory;
+
 import org.junit.Test;
 
 import java.util.ArrayList;
@@ -66,13 +68,18 @@ public class HugeHashMapTest {
                 .setSegments(256)
                 .setSmallEntrySize(72) // TODO 64 corrupts the values !!
                 .setCapacity(count);
+        
+        KeyFlyweighFactory<CharSequenceKey> factory = new KeyFlyweighFactory<CharSequenceKey>() {
+			@Override
+			public CharSequenceKey create() { return CharSequenceKey.createRecyclableKey(); }
+		};
 
-        final HugeHashMap<CharSequence, SampleValues> map =
-                new HugeHashMap<CharSequence, SampleValues>(
-                        config, CharSequence.class, SampleValues.class);
+        final HugeHashMap<CharSequenceKey, SampleValues> map =
+                new HugeHashMap<CharSequenceKey, SampleValues>(
+                        config, factory, CharSequenceKey.class, SampleValues.class);
         long start = System.nanoTime();
         final SampleValues value = new SampleValues();
-        StringBuilder user = new StringBuilder();
+        CharSequenceKey user = CharSequenceKey.createRecyclableKey();
         for (int i = 0; i < count; i++) {
             value.ee = i;
             value.gg = i;
@@ -105,10 +112,15 @@ public class HugeHashMapTest {
                 .setSegments(128)
                 .setSmallEntrySize(72)
                 .setCapacity(COUNT);
+        
+        KeyFlyweighFactory<CharSequenceKey> factory = new KeyFlyweighFactory<CharSequenceKey>() {
+			@Override
+			public CharSequenceKey create() { return CharSequenceKey.createRecyclableKey(); }
+		};
 
-        final HugeHashMap<CharSequence, SampleValues> map =
-                new HugeHashMap<CharSequence, SampleValues>(
-                        config, CharSequence.class, SampleValues.class);
+        final HugeHashMap<CharSequenceKey, SampleValues> map =
+                new HugeHashMap<CharSequenceKey, SampleValues>(
+                        config, factory, CharSequenceKey.class, SampleValues.class);
 
         final String[] users = new String[COUNT];
         for (int i = 0; i < COUNT; i++) users[i] = "user:" + i;
@@ -121,7 +133,7 @@ public class HugeHashMapTest {
                 @Override
                 public void run() {
                     final SampleValues value = new SampleValues();
-                    StringBuilder user = new StringBuilder();
+                    CharSequenceKey user = CharSequenceKey.createRecyclableKey();
                     for (int i = finalT; i < COUNT; i += N_THREADS) {
                         value.ee = i;
                         value.gg = i;
@@ -149,10 +161,8 @@ public class HugeHashMapTest {
         es.shutdown();
     }
 
-    CharSequence users(StringBuilder user, int i) {
-        user.setLength(0);
-        user.append("user:");
-        user.append(i);
+    CharSequenceKey users(CharSequenceKey user, int i) {
+        user.set("user:", i);
         return user;
     }
 
@@ -160,15 +170,20 @@ public class HugeHashMapTest {
     public void testPutLong() {
         HugeConfig config = HugeConfig.DEFAULT.clone();
 
-        HugeHashMap<Long, Long> map1 =
-                new HugeHashMap<Long, Long>(config, Long.class, Long.class);
+        KeyFlyweighFactory<IntKey> factory = new KeyFlyweighFactory<IntKey>() {
+			@Override
+			public IntKey create() { return new IntKey(); }
+		};
+        
+        HugeHashMap<IntKey, Long> map1 =
+                new HugeHashMap<IntKey, Long>(config, factory, IntKey.class, Long.class);
 
-        long key = 55;
+        IntKey key = new IntKey();
 
-        map1.put(key, 10L);
-        assertEquals(10L, map1.get(key));
-        map1.put(key, 20L);
-        assertEquals(20L, map1.get(key));
+        map1.put(key.set(11), 10L);
+        assertEquals(10L, map1.get(key.set(11)));
+        map1.put(key.set(11), 20L);
+        assertEquals(20L, map1.get(key.set(11)));
         map1.clear();
     }
 }

--- a/collections/src/test/java/net/openhft/collections/IntIntMultiMapTest.java
+++ b/collections/src/test/java/net/openhft/collections/IntIntMultiMapTest.java
@@ -90,4 +90,17 @@ public class IntIntMultiMapTest {
 		map.startSearch(15);    		
 		assertEquals(IntIntMultiMap.UNSET, map.nextInt());
     }
+    
+    @Test
+    public void testRemove2Specific() { 
+    	IntIntMultiMap map = new IntIntMultiMap(10); 
+    	map.put(6573, 1);
+    	map.put(6574, 1);
+    	map.put(6701, 1);
+    	
+    	map.remove(6573, 1);
+    	
+    	map.startSearch(6701);
+    	assertNotEquals(IntIntMultiMap.UNSET, map.nextInt());
+    }
 }

--- a/collections/src/test/java/net/openhft/collections/IntKey.java
+++ b/collections/src/test/java/net/openhft/collections/IntKey.java
@@ -1,0 +1,44 @@
+package net.openhft.collections;
+
+import net.openhft.lang.io.Bytes;
+
+public final class IntKey implements HugeMapKey<IntKey> {
+	private int value;
+	
+	public IntKey() {}
+	
+	private IntKey(int value) {
+		this.value = value;
+	}
+	
+	public IntKey set(int value) {
+		this.value = value;
+		return this;
+	}
+
+	@Override
+	public void readMarshallable(Bytes in) throws IllegalStateException {
+		value = in.readInt();
+	}
+
+	@Override
+	public void writeMarshallable(Bytes out) {
+		out.writeInt(value);
+	}
+
+	@Override
+	public IntKey createKeyForPut() {
+		return new IntKey(value);
+	}
+	
+	@Override
+	public boolean equals(Object obj) {
+		if (obj == null || obj.getClass() != getClass()) return false;
+		return value == ((IntKey)obj).value;
+	}
+	
+	@Override
+	public int hashCode() {
+		return value;
+	}
+}

--- a/collections/src/test/java/net/openhft/collections/SegmentTest.java
+++ b/collections/src/test/java/net/openhft/collections/SegmentTest.java
@@ -33,18 +33,19 @@ public class SegmentTest {
         config.setSegments(1);
         config.setSmallEntrySize(32);
         config.setCapacity(config.getSegments() * 32);
-        HugeHashMap.Segment<Integer, String> segment = new HugeHashMap.Segment<Integer, String>(config, false, false, String.class);
-        segment.put(1, 111, "one", true, true);
-        segment.put(1, 112, "two", true, true);
+        HugeHashMap.Segment<IntKey, String> segment = new HugeHashMap.Segment<IntKey, String>(config, new IntKey(), false, String.class);
+        IntKey key = new IntKey();
+        segment.put(1, key.set(111), "one", true, true);
+        segment.put(1, key.set(112), "two", true, true);
         assertEquals(2, segment.size());
-        segment.put(1, 111, "one-one", false, true);
-        assertEquals("one", segment.get(1, 111, null));
-        segment.put(1, 111, "one-one", true, false);
-        assertEquals("one-one", segment.get(1, 111, null));
-        segment.put(1, 113, "four", true, false);
-        assertEquals(null, segment.get(1, 113, null));
-        segment.put(1, 113, "four", false, true);
-        assertEquals("four", segment.get(1, 113, null));
+        segment.put(1, key.set(111), "one-one", false, true);
+        assertEquals("one", segment.get(1, key.set(111), null));
+        segment.put(1, key.set(111), "one-one", true, false);
+        assertEquals("one-one", segment.get(1, key.set(111), null));
+        segment.put(1, key.set(113), "four", true, false);
+        assertEquals(null, segment.get(1, key.set(113), null));
+        segment.put(1, key.set(113), "four", false, true);
+        assertEquals("four", segment.get(1, key.set(113), null));
 
     }
 
@@ -54,55 +55,56 @@ public class SegmentTest {
         config.setSegments(1);
         config.setSmallEntrySize(32);
         config.setCapacity(config.getSegments() * 32);
-        HugeHashMap.Segment<Integer, String> segment = new HugeHashMap.Segment<Integer, String>(config, false, false, String.class);
-        segment.put(1, 111, "one", true, true);
-        segment.put(1, 112, "two", true, true);
-        segment.put(3, 301, "three", true, true);
-        segment.put(1, 113, "four", true, true);
-        segment.put(3, 302, "five", true, true);
-        segment.put(1, 114, "six", true, true);
+        HugeHashMap.Segment<IntKey, String> segment = new HugeHashMap.Segment<IntKey, String>(config, new IntKey(), false, String.class);
+        IntKey key = new IntKey();
+        segment.put(1, key.set(111), "one", true, true);
+        segment.put(1, key.set(112), "two", true, true);
+        segment.put(3, key.set(301), "three", true, true);
+        segment.put(1, key.set(113), "four", true, true);
+        segment.put(3, key.set(302), "five", true, true);
+        segment.put(1, key.set(114), "six", true, true);
         assertEquals(6, segment.size());
 
-        assertEquals("one", segment.get(1, 111, null));
-        assertEquals("two", segment.get(1, 112, null));
-        assertEquals("three", segment.get(3, 301, null));
-        assertEquals("four", segment.get(1, 113, null));
-        assertEquals("five", segment.get(3, 302, null));
-        assertEquals("six", segment.get(1, 114, null));
+        assertEquals("one", segment.get(1, key.set(111), null));
+        assertEquals("two", segment.get(1, key.set(112), null));
+        assertEquals("three", segment.get(3, key.set(301), null));
+        assertEquals("four", segment.get(1, key.set(113), null));
+        assertEquals("five", segment.get(3, key.set(302), null));
+        assertEquals("six", segment.get(1, key.set(114), null));
 
-        assertTrue(segment.remove(1, 111));
+        assertTrue(segment.remove(1, key.set(111)));
         assertEquals(5, segment.size());
-        assertEquals(null, segment.get(1, 111, null));
-        assertEquals("two", segment.get(1, 112, null));
-        assertEquals("three", segment.get(3, 301, null));
-        assertEquals("four", segment.get(1, 113, null));
-        assertEquals("five", segment.get(3, 302, null));
-        assertEquals("six", segment.get(1, 114, null));
+        assertEquals(null, segment.get(1, key.set(111), null));
+        assertEquals("two", segment.get(1, key.set(112), null));
+        assertEquals("three", segment.get(3, key.set(301), null));
+        assertEquals("four", segment.get(1, key.set(113), null));
+        assertEquals("five", segment.get(3, key.set(302), null));
+        assertEquals("six", segment.get(1, key.set(114), null));
 
-        assertTrue(segment.remove(1, 112));
-        assertEquals(null, segment.get(1, 112, null));
-        assertEquals("three", segment.get(3, 301, null));
-        assertEquals("four", segment.get(1, 113, null));
-        assertEquals("five", segment.get(3, 302, null));
-        assertEquals("six", segment.get(1, 114, null));
+        assertTrue(segment.remove(1, key.set(112)));
+        assertEquals(null, segment.get(1, key.set(112), null));
+        assertEquals("three", segment.get(3, key.set(301), null));
+        assertEquals("four", segment.get(1, key.set(113), null));
+        assertEquals("five", segment.get(3, key.set(302), null));
+        assertEquals("six", segment.get(1, key.set(114), null));
 
-        assertTrue(segment.remove(1, 113));
-        assertEquals(null, segment.get(1, 113, null));
-        assertEquals("three", segment.get(3, 301, null));
-        assertEquals("five", segment.get(3, 302, null));
-        assertEquals("six", segment.get(1, 114, null));
+        assertTrue(segment.remove(1, key.set(113)));
+        assertEquals(null, segment.get(1, key.set(113), null));
+        assertEquals("three", segment.get(3, key.set(301), null));
+        assertEquals("five", segment.get(3, key.set(302), null));
+        assertEquals("six", segment.get(1, key.set(114), null));
 
-        assertTrue(segment.remove(1, 114));
-        assertEquals(null, segment.get(1, 114, null));
-        assertEquals("three", segment.get(3, 301, null));
-        assertEquals("five", segment.get(3, 302, null));
+        assertTrue(segment.remove(1, key.set(114)));
+        assertEquals(null, segment.get(1, key.set(114), null));
+        assertEquals("three", segment.get(3, key.set(301), null));
+        assertEquals("five", segment.get(3, key.set(302), null));
 
-        assertTrue(segment.remove(3, 301));
-        assertEquals(null, segment.get(3, 301, null));
-        assertEquals("five", segment.get(3, 302, null));
+        assertTrue(segment.remove(3, key.set(301)));
+        assertEquals(null, segment.get(3, key.set(301), null));
+        assertEquals("five", segment.get(3, key.set(302), null));
 
-        assertTrue(segment.remove(3, 302));
-        assertEquals(null, segment.get(3, 302, null));
+        assertTrue(segment.remove(3, key.set(302)));
+        assertEquals(null, segment.get(3, key.set(302), null));
         assertEquals(0, segment.size());
     }
 }


### PR DESCRIPTION
Current implementation of HugeHashMap handles CharSequence type specifically. It converts it into a string whenever it needs to use CharSequence as a key for standard java.util.HashMap (this is correct because for instance StringBuilder does not override equals and hashCode methods and needs to be converted into a string). Consequently the HugeHashMap creates a new string with every put (line 252, current version of HugeHashMap). 

The proposed modification introduces a concept of reusable vs immutable key. For all operations on java.util.HashMap except put, we use reusable key, for put we MUST create an immutable copy of the reusable key. 

3 additional comments:
1. The API is not as nice as in the original solution but it helps to avoid creating unnecessary objects on the heap and makes sure that reusable key objects are not used as keys for java.util.HashMap.put operation.
2. The proposed modifiation requires that the Key type implements BytesMarshallable interface. This might be too restrictive in some cases (?).
3. I am not sure that all the changes will be accepted but in general I think it is a step in the right direction.
