### PR TITLE
HCOLL 5 Working and 99% complete entrySet(), keySet() and values()

### DIFF
--- a/collections/src/main/java/net/openhft/collections/HashPosMultiMap.java
+++ b/collections/src/main/java/net/openhft/collections/HashPosMultiMap.java
@@ -30,6 +30,16 @@ interface HashPosMultiMap {
     int startSearch(long hash);
 
     /**
+     * @return the first position in the map, -1 otherwise
+     */
+    int firstPos(); //todo: this method doesn't fit nicely in the picture
+
+    /**
+     * @return the next non-empty position
+     */
+    int nextDifferentHashNonEmptyPosition(long hash); //todo: this method doesn't fit nicely in the picture
+
+    /**
      * @return the next position for the last search or negative value
      */
     int nextPos();

--- a/collections/src/main/java/net/openhft/collections/IntIntMultiMap.java
+++ b/collections/src/main/java/net/openhft/collections/IntIntMultiMap.java
@@ -154,6 +154,34 @@ class IntIntMultiMap implements HashPosMultiMap {
     private int searchPos = -1;
 
     @Override
+    public int firstPos() {
+        int pos = 0;
+        while (pos < capacity * ENTRY_SIZE) {
+            long entry = bytes.readLong(pos);
+            int hash2 = (int) (entry >> 32);
+            if (hash2 != UNSET_KEY) {
+                return (int) entry;
+            }
+            pos = pos + ENTRY_SIZE;
+        }
+        return -1;
+    }
+
+    @Override
+    public int nextDifferentHashNonEmptyPosition(long hash) { //todo: merge implementation with first position method
+        startSearch(hash);
+        while (searchPos < capacity * ENTRY_SIZE) {
+            long entry = bytes.readLong(searchPos);
+            int hash2 = (int) (entry >> 32);
+            if (hash2 != UNSET_KEY && hash2 != searchHash) {
+                return (int) entry;
+            }
+            searchPos = searchPos + ENTRY_SIZE;
+        }
+        return -1;
+    }
+
+    @Override
     public int startSearch(int hash) {
         if (hash == UNSET_KEY)
             hash = HASH_INSTEAD_OF_UNSET_KEY;
@@ -172,8 +200,9 @@ class IntIntMultiMap implements HashPosMultiMap {
         for (int i = 0; i < capacity; i++) {
             long entry = bytes.readLong(searchPos);
             int hash2 = (int) (entry >> 32);
-            if (hash2 == UNSET_KEY)
+            if (hash2 == UNSET_KEY) {
                 return UNSET_VALUE;
+            }
             searchPos = (searchPos + ENTRY_SIZE) & capacityMask2;
             if (hash2 == searchHash) {
                 return (int) entry;

--- a/collections/src/test/java/net/openhft/collections/IntIntMultiMapTest.java
+++ b/collections/src/test/java/net/openhft/collections/IntIntMultiMapTest.java
@@ -77,6 +77,18 @@ public class IntIntMultiMapTest {
     }
 
     @Test
+    public void firstAndNextNonEmptyPos() {
+        HashPosMultiMap map = new IntIntMultiMap(16);
+        map.put(1, 11);
+        map.put(2, 22);
+        map.put(3, 33);
+        assertEquals(11, map.firstPos());
+        assertEquals(22, map.nextDifferentHashNonEmptyPosition(1));
+        assertEquals(33, map.nextDifferentHashNonEmptyPosition(2));
+        assertEquals(-1, map.nextDifferentHashNonEmptyPosition(3));
+    }
+
+    @Test
     public void testRemoveSpecific() {
         // Testing a specific case when the remove method on the map does (did) not work as expected. The size goes correctly to
         // 0 but the value is still present in the map.

--- a/collections/src/test/java/net/openhft/collections/SegmentTest.java
+++ b/collections/src/test/java/net/openhft/collections/SegmentTest.java
@@ -33,7 +33,7 @@ public class SegmentTest {
         config.setSegments(1);
         config.setSmallEntrySize(32);
         config.setCapacity(config.getSegments() * 32);
-        HugeHashMap.Segment<Integer, String> segment = new HugeHashMap.Segment<Integer, String>(config, false, false, String.class);
+        HugeHashMap.Segment<Integer, String> segment = new HugeHashMap.Segment<Integer, String>(config, null, false, false, String.class);
         segment.put(1, 111, "one", true, true);
         segment.put(1, 112, "two", true, true);
         assertEquals(2, segment.size());
@@ -54,7 +54,7 @@ public class SegmentTest {
         config.setSegments(1);
         config.setSmallEntrySize(32);
         config.setCapacity(config.getSegments() * 32);
-        HugeHashMap.Segment<Integer, String> segment = new HugeHashMap.Segment<Integer, String>(config, false, false, String.class);
+        HugeHashMap.Segment<Integer, String> segment = new HugeHashMap.Segment<Integer, String>(config, null, false, false, String.class);
         segment.put(1, 111, "one", true, true);
         segment.put(1, 112, "two", true, true);
         segment.put(3, 301, "three", true, true);


### PR DESCRIPTION
Working and 99% complete entrySet(), keySet() and values() methods for HugeHashMap.
I'm missing some functionality for values() (remove to be reflected in the map), but the rest should be there.
Pls. take a look, let me know if it's ok if I go the same way for SHM too, or you would prefer some other approach.

Also found a bug, where size was not properly reset on map.clear().

Also managed to BREAK HugeHashMapTest.testPutPerf(), I don't yet know why... Pls. comment if it's obvious to you, otherwise I'll investigate further. Btw. how do you normally run all the unit tests? From IntelliJ?
